### PR TITLE
docs: fix example usage statement

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: ghcr.io/aslafy-z/conventional-pr-title-action@v2.2.5
+      - uses: aslafy-z/conventional-pr-title-action@v2.2.5
         with:
           success-state: Title follows the specification.
           failure-state: Title does not follow the specification.


### PR DESCRIPTION
The current README has the wrong value after `- uses:` in the [Example Usage](https://github.com/aslafy-z/conventional-pr-title-action#example-usage). 
This leads to ```Error: Unable to resolve action `ghcr.io/aslafy-z@v2.2.5`, repository not found``` .
This change puts in the right action link.