### PR TITLE
feat: adds error message output

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ See [Conventional Commits](https://www.conventionalcommits.org/) for sample titl
 
 ### `error`
 
-In case of an error (success=false) contains the error message for additional processing or usage in notifications.
+In case of an error (`success=false`), contains the error message for additional processing or usage in notifications.
 
 ## Example usage
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ See [Conventional Commits](https://www.conventionalcommits.org/) for sample titl
 
 `true` if the validation succeed. `false` otherwise.
 
+### `error`
+
+In case of an error (success=false) contains the error message for additional processing or usage in notifications.
+
 ## Example usage
 
 ```yaml

--- a/src/index.js
+++ b/src/index.js
@@ -61,6 +61,7 @@ async function run() {
     }
 
   } catch (error) {
+    core.setOutput('error', error.message);
     core.setFailed(error.message);
   }
 };


### PR DESCRIPTION
Adds the error message from the linting process as output so that it can be processed or used in subsequent jobs.

| Q               | A
| --------------- | ---
| Bug fix?        | no |
| New feature?    | yes |
| API breaks?     | no |
| Deprecations?   | no |
| License         | Apache 2.0 |

### What's in this PR?

New output "error" containing the lint error message so that it can be re-used.

### Why?

Sometimes people want to use the exact message from the linting process which contains more details why the linting failed. As there‘s no output with this message it’s impossible to use the message in a notification or process it. This change provides an output "error" which can be used.

### Checklist

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] User guide and development docs updated (if needed)