### PR TITLE
feat: adds targetUrl as input

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ See [Conventional Commits](https://www.conventionalcommits.org/) for sample titl
 
 ### `target-url`
 
-Optional URL to be used when linking the "Details" in the actions overview.
+Optional URL to be used when linking the "Details" in the actions overview. Default `"https://github.com/aslafy-z/conventional-pr-title-action"`.
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ See [Conventional Commits](https://www.conventionalcommits.org/) for sample titl
 
 **Required** Conventional changelog preset. Default `"conventional-changelog-angular"`.
 
+### `target-url`
+
+Optional URL to be used when linking the "Details" in the actions overview.
+
 ## Outputs
 
 ### `success`

--- a/src/index.js
+++ b/src/index.js
@@ -9,6 +9,7 @@ async function run() {
     let contextName = core.getInput('context-name');
     let successState = core.getInput('success-state');
     let failureState = core.getInput('failure-state');
+    let targetUrl = core.getInput('target-url') || 'https://github.com/aslafy-z/conventional-pr-title-action';
     const installPresetPackage = core.getInput('preset');
     const requirePresetPackage = npa(installPresetPackage).name;
 
@@ -49,7 +50,7 @@ async function run() {
         state,
         description,
         sha: contextPullRequest.head.sha,
-        target_url: 'https://github.com/aslafy-z/conventional-pr-title-action',
+        target_url: targetUrl,
         context: contextName,
       },
     );


### PR DESCRIPTION
Adds `target-url` as input which can be used to change the target_url parameter which is used for the "Details" link in the actions result list inside the github workflow summary below a merge-request.

| Q               | A
| --------------- | ---
| Bug fix?        | no |
| New feature?    | yes |
| API breaks?     | no |
| Deprecations?   | no |
| License         | Apache 2.0

### Checklist

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] User guide and development docs updated (if needed)