### PR TITLE
fix(action definition): add missing target_url to action definition

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -18,6 +18,10 @@ inputs:
     description: Conventional changelog preset to use.
     required: true
     default: conventional-changelog-angular
+  target-url:
+    description: URL to be used when linking the "Details" in the actions overview.
+    required: false
+    default: https://github.com/aslafy-z/conventional-pr-title-action
 runs:
   using: docker
   image: Dockerfile


### PR DESCRIPTION
The github action definition is missing the target-url input values

| Q               | A
| --------------- | ---
| Bug fix?        |yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #X, partially #Y, mentioned in #Z
| License         | Apache 2.0


### What's in this PR?
The `action.yml` definition didn't include the `target-url` input section, therefor the action didn't recognize it as a valid input

### Why?
Bug fix



### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [X] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
