### PR TITLE
chore(docker): Using the public docker image

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -24,7 +24,7 @@ inputs:
     default: https://www.conventionalcommits.org/en/v1.0.0/#summary
 runs:
   using: docker
-  image: Dockerfile
+  image: docker://ghcr.io/aslafy-z/conventional-pr-title-action
 branding:
   icon: shield
   color: green


### PR DESCRIPTION
Using the public docker image instead of building Dockerfile each time. 

![image](https://user-images.githubusercontent.com/2082472/228168988-00eaf581-1041-45f9-91b1-d507a984b325.png)
