### PR TITLE
feat: Docker optimizations to improve run time

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,4 @@
-.git/
-node_modules/
-
+*
+!package.json
+!package-lock.json
+!src

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
+dist/
 node_modules/
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,19 @@
+FROM node:20-alpine AS builder
+
+WORKDIR /action
+
+COPY package.json package-lock.json ./
+
+RUN npm ci
+
+COPY src ./src
+
+RUN npm run build
+
 FROM node:20-alpine
 
-ADD package.json package-lock.json /action/
-RUN cd /action && npm ci
+WORKDIR /action
 
-ADD src /action/src
-ENTRYPOINT ["node", "/action/src/index.js"]
+COPY --from=builder /action/dist ./dist
+
+CMD ["./dist/index.js"]

--- a/action.yml
+++ b/action.yml
@@ -24,7 +24,7 @@ inputs:
     default: https://www.conventionalcommits.org/en/v1.0.0/#summary
 runs:
   using: docker
-  image: Dockerfile
+  image: docker://ghcr.io/aslafy-z/conventional-pr-title-action
 branding:
   icon: shield
   color: green

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "npm-package-arg": "^10.1.0"
       },
       "devDependencies": {
+        "@vercel/ncc": "^0.36.1",
         "jest": "29.6.2"
       },
       "engines": {
@@ -1276,6 +1277,15 @@
       "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.0.tgz",
       "integrity": "sha512-iO9ZQHkZxHn4mSakYV0vFHAVDyEOIJQrV2uZ06HxEPcx+mt8swXoZHIbaaJ2crJYFfErySgktuTZ3BeLz+XmFA==",
       "dev": true
+    },
+    "node_modules/@vercel/ncc": {
+      "version": "0.36.1",
+      "resolved": "https://registry.npmjs.org/@vercel/ncc/-/ncc-0.36.1.tgz",
+      "integrity": "sha512-S4cL7Taa9yb5qbv+6wLgiKVZ03Qfkc4jGRuiUQMQ8HGBD5pcNRnHeYM33zBvJE4/zJGjJJ8GScB+WmTsn9mORw==",
+      "dev": true,
+      "bin": {
+        "ncc": "dist/ncc/cli.js"
+      }
     },
     "node_modules/ansi-escapes": {
       "version": "4.3.2",
@@ -5336,6 +5346,12 @@
       "version": "21.0.0",
       "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.0.tgz",
       "integrity": "sha512-iO9ZQHkZxHn4mSakYV0vFHAVDyEOIJQrV2uZ06HxEPcx+mt8swXoZHIbaaJ2crJYFfErySgktuTZ3BeLz+XmFA==",
+      "dev": true
+    },
+    "@vercel/ncc": {
+      "version": "0.36.1",
+      "resolved": "https://registry.npmjs.org/@vercel/ncc/-/ncc-0.36.1.tgz",
+      "integrity": "sha512-S4cL7Taa9yb5qbv+6wLgiKVZ03Qfkc4jGRuiUQMQ8HGBD5pcNRnHeYM33zBvJE4/zJGjJJ8GScB+WmTsn9mORw==",
       "dev": true
     },
     "ansi-escapes": {

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Ensure your PR title matches the Conventional Commits spec.",
   "main": "src/index.js",
   "scripts": {
+    "build": "ncc build src/index.js -o dist",
     "test": "jest src",
     "release": "semantic-release"
   },
@@ -30,6 +31,7 @@
     "npm-package-arg": "^10.1.0"
   },
   "devDependencies": {
+    "@vercel/ncc": "^0.36.1",
     "jest": "29.6.2"
   },
   "engines": {

--- a/src/installPreset.js
+++ b/src/installPreset.js
@@ -11,6 +11,7 @@ module.exports = async (preset) => {
   const {stdout, stderr} = await exec(`npm install --quiet ${preset}`, {
     cwd: path.resolve(__dirname)
   });
+  core.debug(stdout);
   core.debug(stderr);
   return Promise.resolve();
 };


### PR DESCRIPTION
Following #285

This PR improves run time by making the following Docker optimizations:
- Use public Docker image from `ghcr` instead of building it at every run
- Leverage [`@vercel/ncc`](https://www.npmjs.com/package/@vercel/ncc) and multi-stage build to reduce the final image size (from 240MB to 180MB, see below)

```bash
$ docker images
REPOSITORY                    TAG           IMAGE ID       CREATED          SIZE
action-node-multi             latest        902e7b743d17   3 minutes ago    180MB
action-node                   latest        6cd06307972c   3 minutes ago    240MB
```

Migrating to a node engine instead of Docker seems more difficult. To be able to install a `npm` package, users should add an extra step `actions/setup-node` before using the action, which is not convenient. Another way to install a `npm` package is to use the [`npm`](https://www.npmjs.com/package/npm) programmatic API, but it has been removed since version 8.0.0, so I don't think it's a great idea.

Anyway, performance improvements are not as significant as using a node engine. But with these changes, the Docker image does not contain the entire`node_modules` folder and the image is not built at each run.

## Results

Before: 
![image](https://github.com/aslafy-z/conventional-pr-title-action/assets/44783088/375504a6-8392-4ccf-b6fa-45626cc43f2c)

After:
![image](https://github.com/aslafy-z/conventional-pr-title-action/assets/44783088/f041683e-6bd0-4d76-aa41-412e084d9647)
