### PR TITLE
ci: update semantic-release preset configuration

### DIFF
--- a/release.config.js
+++ b/release.config.js
@@ -1,9 +1,12 @@
 module.exports = {
-  preset: "conventionalcommits",
   branches: ["main"],
   plugins: [
-    "@semantic-release/commit-analyzer",
-    "@semantic-release/release-notes-generator",
+    ["@semantic-release/commit-analyzer", {
+      "preset": "conventionalcommits",
+    }],
+    ["@semantic-release/release-notes-generator", {
+      "preset": "conventionalcommits",
+    }],
     "@semantic-release/git",
     "@semantic-release/github",
   ],


### PR DESCRIPTION
Ref https://github.com/aslafy-z/conventional-pr-title-action/pull/285#discussion_r1289990865

Looks like we're using a deprecated preset configuration method. Moving to the documented one.