### PR TITLE
feat: support for scope-required input

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,11 @@ See [Conventional Commits](https://www.conventionalcommits.org/) for sample titl
 **Optional.** URL to be used when linking the "Details" in the actions overview.
 > Default: `"https://www.conventionalcommits.org/en/v1.0.0/#summary"`.
 
+### `scope-required`
+
+**Optional.** Set to `true` if you want to fail in case the scope isn't set.
+> Default: `false`.
+
 ## Outputs
 
 ### `success`

--- a/action.yml
+++ b/action.yml
@@ -22,6 +22,11 @@ inputs:
     description: URL to be used when linking the "Details" in the actions overview.
     required: false
     default: https://www.conventionalcommits.org/en/v1.0.0/#summary
+  scope-required:
+    description: Set to true if you want to fail in case the scope isn't set
+    required: false
+    default: false
+    type: boolean
 runs:
   using: docker
   image: Dockerfile

--- a/action.yml
+++ b/action.yml
@@ -23,7 +23,7 @@ inputs:
     required: false
     default: https://www.conventionalcommits.org/en/v1.0.0/#summary
   scope-required:
-    description: Set to true if you want to fail in case the scope isn't set
+    description: Set to true if you want to fail in case the scope isn't set.
     required: false
     default: false
     type: boolean

--- a/src/index.js
+++ b/src/index.js
@@ -10,8 +10,8 @@ async function run() {
     let successState = core.getInput('success-state');
     let failureState = core.getInput('failure-state');
     let targetUrl = core.getInput('target-url');
-    let scopeRequired = core.getInput("scope-required");
-    const installPresetPackage = core.getInput("preset");
+    let scopeRequired = core.getInput('scope-required');
+    const installPresetPackage = core.getInput('preset');
     const requirePresetPackage = npa(installPresetPackage).name;
 
     const client = new github.getOctokit(process.env.GITHUB_TOKEN);

--- a/src/index.js
+++ b/src/index.js
@@ -10,7 +10,8 @@ async function run() {
     let successState = core.getInput('success-state');
     let failureState = core.getInput('failure-state');
     let targetUrl = core.getInput('target-url');
-    const installPresetPackage = core.getInput('preset');
+    let scopeRequired = core.getInput("scope-required");
+    const installPresetPackage = core.getInput("preset");
     const requirePresetPackage = npa(installPresetPackage).name;
 
     const client = new github.getOctokit(process.env.GITHUB_TOKEN);
@@ -28,7 +29,11 @@ async function run() {
     let error = null;
     try {
       await installPreset(installPresetPackage);
-      await validateTitle(requirePresetPackage, contextPullRequest.title);
+      await validateTitle(
+        requirePresetPackage,
+        contextPullRequest.title,
+        scopeRequired
+      );
     } catch (err) {
       error = err;
     }

--- a/src/validateTitle.js
+++ b/src/validateTitle.js
@@ -5,7 +5,7 @@ function isFunction(functionToCheck) {
   return functionToCheck && {}.toString.call(functionToCheck) === '[object Function]';
 }
 
-module.exports = async function validateTitle(preset, title) {
+module.exports = async function validateTitle(preset, title, scopeRequired) {
   let conventionalChangelogConfig = require(preset);
   if (isFunction(conventionalChangelogConfig)) {
     conventionalChangelogConfig = await conventionalChangelogConfig();
@@ -18,9 +18,9 @@ module.exports = async function validateTitle(preset, title) {
   if (!result.type) {
     throw new Error(
       `No release type found in pull request title "${title}". The title should match the commit message format as specified by https://www.conventionalcommits.org/. The functionalities can also be altered by the selected preset plugin (${preset}). ` +
-      `\n\nPlease use one of these recognized types: ${allowedTypes.join(
-        ', '
-      )}.`
+        `\n\nPlease use one of these recognized types: ${allowedTypes.join(
+          ", "
+        )}.`
     );
   }
 
@@ -28,8 +28,14 @@ module.exports = async function validateTitle(preset, title) {
     throw new Error(
       `Unknown release type "${result.type}" found in pull request title "${title}".` +
         `\n\nPlease use one of these recognized types: ${allowedTypes.join(
-          ', '
+          ", "
         )}.`
+    );
+  }
+
+  if (scopeRequired && !result.scope) {
+    throw new Error(
+      `No scope found in pull request title "${title}" but it's required.`
     );
   }
 };

--- a/src/validateTitle.js
+++ b/src/validateTitle.js
@@ -18,18 +18,18 @@ module.exports = async function validateTitle(preset, title, scopeRequired) {
   if (!result.type) {
     throw new Error(
       `No release type found in pull request title "${title}". The title should match the commit message format as specified by https://www.conventionalcommits.org/. The functionalities can also be altered by the selected preset plugin (${preset}). ` +
-        `\n\nPlease use one of these recognized types: ${allowedTypes.join(
-          ", "
-        )}.`
+      `\n\nPlease use one of these recognized types: ${allowedTypes.join(
+        ', '
+      )}.`
     );
   }
 
   if (!allowedTypes.includes(result.type)) {
     throw new Error(
       `Unknown release type "${result.type}" found in pull request title "${title}".` +
-        `\n\nPlease use one of these recognized types: ${allowedTypes.join(
-          ", "
-        )}.`
+      `\n\nPlease use one of these recognized types: ${allowedTypes.join(
+        ', '
+      )}.`
     );
   }
 

--- a/src/validateTitle.js
+++ b/src/validateTitle.js
@@ -27,9 +27,9 @@ module.exports = async function validateTitle(preset, title, scopeRequired) {
   if (!allowedTypes.includes(result.type)) {
     throw new Error(
       `Unknown release type "${result.type}" found in pull request title "${title}".` +
-      `\n\nPlease use one of these recognized types: ${allowedTypes.join(
-        ', '
-      )}.`
+        `\n\nPlease use one of these recognized types: ${allowedTypes.join(
+          ', '
+        )}.`
     );
   }
 

--- a/src/validateTitle.test.js
+++ b/src/validateTitle.test.js
@@ -41,3 +41,9 @@ it('throws for PR titles with an unknown type', async () => {
     /Unknown release type "foo" found in pull request title "foo: Bar"./
   );
 });
+
+it('throws for PR titles without a scope when its required', async () => {
+  await expect(validateTitle(preset, 'feat: Add feature', true)).rejects.toThrow(
+    /No scope found in pull request title "feat: Add feature" but it's required./
+  );
+});


### PR DESCRIPTION
We have a monorepo and would like to restrict our conventional commits to always have a scope defined